### PR TITLE
Handle the case where the float separator is a comma instead of a dot

### DIFF
--- a/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
+++ b/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
@@ -1,17 +1,32 @@
 package com.codacy.parsers.implementation
 
 import java.io.File
+import java.util.Locale
+import java.text.NumberFormat
 
 import com.codacy.api.{CoverageFileReport, CoverageReport, Language}
 import com.codacy.parsers.XMLCoverageParser
 import com.codacy.parsers.util.LanguageUtils
 
 import scala.xml.Node
+import scala.util.Try
 
 class CoberturaParser(val language: Language.Value, val rootProject: File, val coverageReport: File) extends XMLCoverageParser {
 
   val rootProjectDir = rootProject.getAbsolutePath + File.separator
   lazy val allFiles = recursiveListFiles(rootProject)(f => f.getName.endsWith(LanguageUtils.getExtension(language)))
+
+  private[this] def convertToFloat(str: String): Try[Float] = {
+    Try(str.toFloat).recoverWith {
+      case ex =>
+        Try {
+          // The french locale uses the comma as a sep.
+          val instance = NumberFormat.getInstance(Locale.FRANCE)
+          val number = instance.parse(str)
+          number.floatValue()
+        }
+    }
+  }
 
   private def recursiveListFiles(root: File)(filter: File => Boolean): Array[File] = {
     val these = root.listFiles
@@ -25,7 +40,8 @@ class CoberturaParser(val language: Language.Value, val rootProject: File, val c
   def generateReport(): CoverageReport = {
     val total = (xml \\ "coverage" \ "@line-rate").headOption.map {
       total =>
-        (total.text.toFloat * 100).toInt
+        val totalValue = convertToFloat(total.text)
+        (totalValue.getOrElse(0.0f) * 100).toInt
     }.getOrElse(0)
 
     val files = (xml \\ "class" \\ "@filename").map(_.text).toSet
@@ -46,7 +62,8 @@ class CoberturaParser(val language: Language.Value, val rootProject: File, val c
 
     val classHit = (file \\ "@line-rate").map {
       total =>
-        (total.text.toFloat * 100).toInt
+        val totalValue = convertToFloat(total.text)
+        (totalValue.getOrElse(0.0f) * 100).toInt
     }
 
     val fileHit = classHit.sum / classHit.length

--- a/src/test/resources/thousand_sep_cobertura.xml
+++ b/src/test/resources/thousand_sep_cobertura.xml
@@ -1,0 +1,31 @@
+<coverage line-rate="0.87">
+    <packages>
+        <package line-rate="0,87" name="com.github.theon.coveralls">
+            <classes>
+                <class line-rate="0,87" name="TestSourceFile" filename="src/test/resources/TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                        <line number="6" hits="2"/>
+                    </lines>
+                </class>
+                <class line-rate="0,87" name="TestSourceFile" filename="src/test/resources/TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="9" hits="1"/>
+                        <line number="10" hits="1"/>
+                    </lines>
+                </class>
+                <class line-rate="0,87" name="TestSourceFile2" filename="src/test/resources/TestSourceFile2.scala">
+                    <methods/>
+                    <lines>
+                        <line number="1" hits="1"/>
+                        <line number="2" hits="1"/>
+                        <line number="3" hits="1"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/src/test/scala/com/codacy/parsers/CoberturaParserTest.scala
+++ b/src/test/scala/com/codacy/parsers/CoberturaParserTest.scala
@@ -34,6 +34,18 @@ class CoberturaParserTest extends WordSpec with BeforeAndAfterAll with Matchers 
       reader.generateReport() shouldEqual testReport
     }
 
+    "no crash on thousands separators" in {
+      val reader = new CoberturaParser(Language.Scala, new File("."), new File("src/test/resources/thousand_sep_cobertura.xml"))
+
+      val testReport = CoverageReport(Language.Scala, 87, List(
+        CoverageFileReport("src/test/resources/TestSourceFile.scala", 87,
+          Map(5 -> 1, 10 -> 1, 6 -> 2, 9 -> 1, 4 -> 1)),
+        CoverageFileReport("src/test/resources/TestSourceFile2.scala", 87,
+          Map(1 -> 1, 2 -> 1, 3 -> 1))))
+
+      reader.generateReport() shouldEqual testReport
+    }
+
   }
 
 }


### PR DESCRIPTION
(FT-1595)

Let me know if you like this approach, of using a locale known for having commas, or just replacing the comma with a dot and be over with. 