### PR TITLE
Fixes for cobertura and jacoco parsing on Windows

### DIFF
--- a/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
+++ b/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
@@ -88,7 +88,7 @@ class CoberturaParser(val language: Language.Value, val rootProject: File, val c
   private def sanitiseFilename(filename: String): String = {
     filename
       .replaceAll("""\\/""", "/") // Fix for paths with \/
-      .replace("\\", "/") // Fix for paths with \\
+      .replace("\\", "/") // Fix for paths with \
   }
 
   private def stripRoot(filename: String): String = {

--- a/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
+++ b/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
@@ -13,7 +13,7 @@ import scala.util.Try
 
 class CoberturaParser(val language: Language.Value, val rootProject: File, val coverageReport: File) extends XMLCoverageParser {
 
-  val rootProjectDir = rootProject.getAbsolutePath + File.separator
+  val rootProjectDir = sanitiseFilename(rootProject.getAbsolutePath + File.separator)
   lazy val allFiles = recursiveListFiles(rootProject)(f => f.getName.endsWith(LanguageUtils.getExtension(language)))
 
   private[this] def convertToFloat(str: String): Try[Float] = {
@@ -79,16 +79,20 @@ class CoberturaParser(val language: Language.Value, val rootProject: File, val c
         key -> value
     }
 
-    allFiles.find(f => f.getAbsolutePath.endsWith(sourceFilename)).map {
+    allFiles.map(f => sanitiseFilename(f.getAbsolutePath)).find(f => f.endsWith(sourceFilename)).map {
       filename =>
-        CoverageFileReport(sanitiseFilename(filename.getAbsolutePath), fileHit, lineHitMap)
+        CoverageFileReport(stripRoot(filename), fileHit, lineHitMap)
     }
   }
 
   private def sanitiseFilename(filename: String): String = {
-    filename.stripPrefix(rootProjectDir)
+    filename
       .replaceAll("""\\/""", "/") // Fix for paths with \/
       .replace("\\", "/") // Fix for paths with \\
+  }
+
+  private def stripRoot(filename: String): String = {
+    filename.stripPrefix(rootProjectDir)
   }
 
 }

--- a/src/main/scala/com/codacy/parsers/implementation/JacocoParser.scala
+++ b/src/main/scala/com/codacy/parsers/implementation/JacocoParser.scala
@@ -29,7 +29,7 @@ class JacocoParser(val language: Language.Value, val rootProject: File, val cove
         (`package` \\ "sourcefile").map {
           file =>
             val filename = (file \ "@name").text
-            lineCoverage(packageName + File.separator + filename, file)
+            lineCoverage(packageName + "/" + filename, file)
         }
     }
 


### PR DESCRIPTION
Tests now pass on both windows and linux (they were previously failing on windows hosts)