### PR TITLE
Fix file path comparison

### DIFF
--- a/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
+++ b/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
@@ -89,7 +89,7 @@ class CoberturaParser(val language: Language.Value, val rootProject: File, val c
         key -> value
     }
 
-    allFiles.find(f => f.endsWith(sourceFilename)).map {
+    allFiles.find(f => f.endsWith(sanitiseFilename(sourceFilename))).map {
       filename =>
         CoverageFileReport(stripRoot(filename), fileHit, lineHitMap)
     }

--- a/src/test/resources/windows_paths_cobertura.xml
+++ b/src/test/resources/windows_paths_cobertura.xml
@@ -1,0 +1,32 @@
+<coverage line-rate="0.87">
+    <packages>
+        <package line-rate="0.87" name="com.github.theon.coveralls">
+            <classes>
+                <class line-rate="0.87" name="TestSourceFile" filename="src\test\resources\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="3" hits="0"/>
+                        <line number="4" hits="1"/>
+                        <line number="5" hits="1"/>
+                        <line number="6" hits="2"/>
+                    </lines>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile" filename="src\test\resources\TestSourceFile.scala">
+                    <methods/>
+                    <lines>
+                        <line number="9" hits="1"/>
+                        <line number="10" hits="1"/>
+                    </lines>
+                </class>
+                <class line-rate="0.87" name="TestSourceFile2" filename="src\test\resources\TestSourceFile2.scala">
+                    <methods/>
+                    <lines>
+                        <line number="1" hits="1"/>
+                        <line number="2" hits="1"/>
+                        <line number="3" hits="1"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+    </packages>
+</coverage>

--- a/src/test/scala/com/codacy/parsers/CoberturaParserTest.scala
+++ b/src/test/scala/com/codacy/parsers/CoberturaParserTest.scala
@@ -46,6 +46,18 @@ class CoberturaParserTest extends WordSpec with BeforeAndAfterAll with Matchers 
       reader.generateReport() shouldEqual testReport
     }
 
+    "return a valid report with windows file path separator" in {
+      val reader = new CoberturaParser(Language.Scala, new File("."), new File("src/test/resources/windows_paths_cobertura.xml"))
+
+      val testReport = CoverageReport(87, List(
+        CoverageFileReport("src/test/resources/TestSourceFile.scala", 87,
+          Map(5 -> 1, 10 -> 1, 6 -> 2, 9 -> 1, 3 -> 0, 4 -> 1)),
+        CoverageFileReport("src/test/resources/TestSourceFile2.scala", 87,
+          Map(1 -> 1, 2 -> 1, 3 -> 1))))
+
+      reader.generateReport() shouldEqual testReport
+    }
+
   }
 
 }


### PR DESCRIPTION
Even if the forward slashes wouldn’t be supported, we are only using them to compare the paths, so they must be sanitized on both sides of the comparison.