### PR TITLE
doc: Update the supported coverage formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 
 Scala library for parsing coverage reports.
 
-The parsers in this project receive as input two parameters, the project root folder and the coverage report.
-As a result of the parse operation, it will produce a CoverageReport, a class that is compatible with the
-[Codacy coverage format](https://support.codacy.com/hc/en-us/articles/207279819-Coverage).
+The parsers in this project receive as input two parameters, the project root folder, and the coverage report file.
+As a result of the parse operation, it will produce either a CoverageReport, a class that is compatible with the
+[Codacy coverage format](https://support.codacy.com/hc/en-us/articles/207279819-Coverage) or a string describing the
+error parsing the coverage report file.
 
 ## Supported formats
 
@@ -24,8 +25,7 @@ Check the table for the formats we support and which coverage tools generate the
 | PHP        | [PHPUnit](https://phpunit.readthedocs.io/en/8.5/code-coverage-analysis.html) | PHPUnit XML <br> [Clover](https://confluence.atlassian.com/clover/using-clover-for-php-420973033.html) |
 | Ruby       | [SimpleCov](https://github.com/colszowka/simplecov) | [Cobertura](https://github.com/dashingrocket/simplecov-cobertura) <br> [LCOV](https://github.com/fortissimo1997/simplecov-lcov) |
 
-Even if you cannot find your language or coverage tool of choice in this table,
-you can still use this parser for the supported formats listed above.
+You can use this parser with any of the listed coverage formats, even if your language or coverage tool of choice is not in the table above.
 If your coverage reports are in a different format you can use a format converter, such as
 [ReportGenerator](https://danielpalme.github.io/ReportGenerator/), to generate a supported format.
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,28 @@
 
 Scala library for parsing coverage reports.
 
-Currently we support [Jacoco](http://eclemma.org/jacoco/), [Cobertura](http://cobertura.github.io/cobertura/) and
-[Clover](https://confluence.atlassian.com/clover/using-clover-for-php-420973033.html) reports.
+The parsers in this project receive as input two parameters, the project root folder and the coverage report.
+As a result of the parse operation, it will produce a CoverageReport, a class that is compatible with the
+[Codacy coverage format](https://support.codacy.com/hc/en-us/articles/207279819-Coverage).
 
-All parsers receive the project root and the file containing the coverage report, producing the
-[Codacy coverage format](https://support.codacy.com/hc/en-us/articles/207279819-Coverage) 
+## Supported formats
+
+Check the table for the formats we support and which coverage tools write to them:
+
+| Language   | Coverage tools (examples) | Formats   |
+| ---        | ---                       | ---       |
+| Java       | [JaCoCo](http://eclemma.org/jacoco/) <br> [Cobertura](http://cobertura.github.io/cobertura/) | JaCoCo <br> Cobertura |
+| Scala      | [sbt-jacoco](https://www.scala-sbt.org/sbt-jacoco/) <br> [scoverage](http://scoverage.org/) | JaCoCo <br> Cobertura |
+| Javascript | [Istanbul](https://github.com/gotwarlost/istanbul) <br> [Poncho](https://github.com/deepsweet/poncho) <br> [Mocha](http://mochajs.org/) + [Blanket.js](https://github.com/alex-seville/blanket) | LCOV |
+| Python     | [Coverage.py](https://coverage.readthedocs.io/en/coverage-5.0.3/) | Cobertura                 |
+| PHP        | [PHPUnit](https://phpunit.readthedocs.io/en/8.5/code-coverage-analysis.html) | PHPUnit XML <br> [Clover](https://confluence.atlassian.com/clover/using-clover-for-php-420973033.html) |
+| Ruby       | [SimpleCov](https://github.com/colszowka/simplecov) | [Cobertura](https://github.com/dashingrocket/simplecov-cobertura) <br> [LCOV](https://github.com/fortissimo1997/simplecov-lcov) |
+
 
 Usage:
 
 ```
-val reader = CoberturaParser.parse(rootProjectDir, coberturaFile)
+val reader: Either[String, CoverageReport] = CoverageParser.parse(rootProjectDir, coberturaFile)
 ```
 
 ## What is Codacy?

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Check the table for the formats we support and which coverage tools generate the
 | PHP        | [PHPUnit](https://phpunit.readthedocs.io/en/8.5/code-coverage-analysis.html) | PHPUnit XML <br> [Clover](https://confluence.atlassian.com/clover/using-clover-for-php-420973033.html) |
 | Ruby       | [SimpleCov](https://github.com/colszowka/simplecov) | [Cobertura](https://github.com/dashingrocket/simplecov-cobertura) <br> [LCOV](https://github.com/fortissimo1997/simplecov-lcov) |
 
+Even if you cannot find your language or coverage tool of choice in this table,
+you can still use this parser for the supported formats listed above.
+If your coverage reports are in a different format you can use a format converter, such as
+[ReportGenerator](https://danielpalme.github.io/ReportGenerator/), to generate a supported format.
 
 Usage:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ As a result of the parse operation, it will produce a CoverageReport, a class th
 
 ## Supported formats
 
-Check the table for the formats we support and which coverage tools write to them:
+Check the table for the formats we support and which coverage tools generate them:
 
 | Language   | Coverage tools (examples) | Formats   |
 | ---        | ---                       | ---       |


### PR DESCRIPTION
Change the way we show the supported formats to increase focus on languages and tools.
Also, make it easier to add new ones in the future.

Fixes #47