### PR TITLE
bump: Bump codacy-api-scala

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Codacy {
-    val scalaApi = "com.codacy" %% "codacy-api-scala" % "4.0.0"
+    val scalaApi = "com.codacy" %% "codacy-api-scala" % "4.0.1"
     val pluginsApi = "com.codacy" %% "codacy-plugins-api" % "3.0.293"
   }
 


### PR DESCRIPTION
We need the new version in codacy-coverage-reporter which consumes this repository