### PR TITLE
Fix lcov returning Rigth with xml / Performance improvement / Optionally force the parser

### DIFF
--- a/src/main/scala/com/codacy/parsers/CoverageParser.scala
+++ b/src/main/scala/com/codacy/parsers/CoverageParser.scala
@@ -35,8 +35,8 @@ object CoverageParser {
 
     object ParsedCoverage {
       def unapply(parser: CoverageParser): Option[CoverageReport] = {
-        parser.parse(projectRoot, reportFile)
-      }.toOption
+        parser.parse(projectRoot, reportFile).toOption
+      }
     }
 
     if (isEmptyReport) {

--- a/src/main/scala/com/codacy/parsers/CoverageParser.scala
+++ b/src/main/scala/com/codacy/parsers/CoverageParser.scala
@@ -15,21 +15,37 @@ trait CoverageParser {
 
 object CoverageParser {
 
-  val parsers: List[CoverageParser] =
+  val allParsers: List[CoverageParser] =
     List(CoberturaParser, JacocoParser, CloverParser, OpenCoverParser, DotcoverParser, PhpUnitXmlParser, LCOVParser)
 
-  def parse(projectRoot: File, reportFile: File): Either[String, CoverageReport] = {
+  def parse(
+      projectRoot: File,
+      reportFile: File,
+      forceParser: Option[CoverageParser] = None
+  ): Either[String, CoverageReport] = {
     val isEmptyReport = {
       // Just starting by detecting the simplest case: a single report file
       Try(reportFile.isFile && reportFile.length() == 0).getOrElse(false)
     }
 
+    val parsers = forceParser match {
+      case Some(parser) => List(parser)
+      case _ => allParsers
+    }
+
+    object ParsedCoverage {
+      def unapply(parser: CoverageParser): Option[CoverageReport] = {
+        parser.parse(projectRoot, reportFile)
+      }.toOption
+    }
+
     if (isEmptyReport) {
       Left(s"Report file ${reportFile.getCanonicalPath} is empty")
     } else {
-      parsers.toStream
-        .map(_.parse(projectRoot, reportFile))
-        .find(_.isRight)
+      parsers.view
+        .collectFirst {
+          case ParsedCoverage(report: CoverageReport) => Right(report)
+        }
         .getOrElse(
           Left(s"Could not parse report, unrecognized report format (tried: ${parsers.map(_.name).mkString(", ")})")
         )

--- a/src/main/scala/com/codacy/parsers/implementation/LCOVParser.scala
+++ b/src/main/scala/com/codacy/parsers/implementation/LCOVParser.scala
@@ -4,7 +4,7 @@ import com.codacy.parsers.CoverageParser
 import com.codacy.api.{CoverageFileReport, CoverageReport}
 import java.io.File
 
-import com.codacy.parsers.util.MathUtils
+import com.codacy.parsers.util.{MathUtils, XMLoader}
 
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
@@ -17,9 +17,11 @@ object LCOVParser extends CoverageParser {
 
   override def parse(rootProject: File, reportFile: File): Either[String, CoverageReport] = {
     val report = Try(Source.fromFile(reportFile)) match {
+      case Success(lines) if Try(XMLoader.loadFile(reportFile)).isSuccess =>
+        Left(s"The file is not in the lcov format but is an xml.")
       case Success(lines) =>
+        val xml = Try(XMLoader.loadFile(reportFile))
         Right(lines.getLines)
-
       case Failure(ex) =>
         Left(s"Can't load report file. ${ex.getMessage}")
     }

--- a/src/main/scala/com/codacy/parsers/implementation/LCOVParser.scala
+++ b/src/main/scala/com/codacy/parsers/implementation/LCOVParser.scala
@@ -20,7 +20,6 @@ object LCOVParser extends CoverageParser {
       case Success(lines) if Try(XMLoader.loadFile(reportFile)).isSuccess =>
         Left(s"The file is not in the lcov format but is an xml.")
       case Success(lines) =>
-        val xml = Try(XMLoader.loadFile(reportFile))
         Right(lines.getLines)
       case Failure(ex) =>
         Left(s"Can't load report file. ${ex.getMessage}")

--- a/src/main/scala/com/codacy/parsers/implementation/LCOVParser.scala
+++ b/src/main/scala/com/codacy/parsers/implementation/LCOVParser.scala
@@ -17,6 +17,7 @@ object LCOVParser extends CoverageParser {
 
   override def parse(rootProject: File, reportFile: File): Either[String, CoverageReport] = {
     val report = Try(Source.fromFile(reportFile)) match {
+      // most reports are XML, and we want to ensure the LCOV parser won't mishandle it and return an empty result
       case Success(lines) if Try(XMLoader.loadFile(reportFile)).isSuccess =>
         Left(s"The file is not in the lcov format but is an xml.")
       case Success(lines) =>

--- a/src/test/scala/com/codacy/parsers/CoverageParserTest.scala
+++ b/src/test/scala/com/codacy/parsers/CoverageParserTest.scala
@@ -1,0 +1,38 @@
+package com.codacy.parsers
+
+import java.io.File
+import com.codacy.parsers.implementation._
+
+import org.scalatest.{BeforeAndAfterAll, EitherValues, Matchers, WordSpec}
+
+class CoverageParserTest extends WordSpec with BeforeAndAfterAll with Matchers with EitherValues {
+  private val coberturaReportPath = "src/test/resources/test_cobertura.xml"
+  private val cloverReportPath = "src/test/resources/test_clover.xml"
+
+  "parse" should {
+    "return the specific error" when {
+      "the file cannot be parsed with a specific parser" in {
+        val reader = CoverageParser.parse(new File("."), new File(coberturaReportPath), Some(CloverParser))
+
+        reader shouldBe 'left
+      }
+      "the file cannot be parsed with another specific parser" in {
+        val reader = CoverageParser.parse(new File("."), new File(coberturaReportPath), Some(LCOVParser))
+
+        reader shouldBe 'left
+      }
+    }
+    "return a valid result" when {
+      "file and format are matching cobertura" in {
+        val reader = CoverageParser.parse(new File("."), new File(coberturaReportPath), Some(CoberturaParser))
+
+        reader shouldBe 'right
+      }
+      "file and format are matching clover" in {
+        val reader = CoverageParser.parse(new File("."), new File(cloverReportPath), Some(CloverParser))
+
+        reader shouldBe 'right
+      }
+    }
+  }
+}

--- a/src/test/scala/com/codacy/parsers/LCOVParserTest.scala
+++ b/src/test/scala/com/codacy/parsers/LCOVParserTest.scala
@@ -15,6 +15,16 @@ class LCOVParserTest extends WordSpec with BeforeAndAfterAll with Matchers with 
       reader.isLeft shouldBe true
     }
 
+    "identify if report is invalid beacuse is cobertura format" in {
+      val reader = LCOVParser.parse(new File("."), new File("src/test/resources/test_cobertura.xml"))
+      reader.isLeft shouldBe true
+    }
+
+    "identify if report is invalid beacuse is clover format" in {
+      val reader = LCOVParser.parse(new File("."), new File("src/test/resources/test_clover.xml"))
+      reader.isLeft shouldBe true
+    }
+
     "identify if report is valid" in {
       val reader = LCOVParser.parse(new File("."), new File("src/test/resources/test_lcov.lcov"))
       reader.isRight shouldBe true


### PR DESCRIPTION
This Pr contains 3 improvements:
 - Fail instead of returning `Right` with 0 elements when running LCOV on xml files -> this enable better experience for the users
 - Stop parsing with all the parsers all the times if one succeed
 - Add the option to force a specific parser to make it easier to debug issues with customers (this should be leveraged in the `coverage-reporter`)