### PR TITLE
fix: Approximate to Int.MaxValue when a value is too big CY-3310

### DIFF
--- a/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
+++ b/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
@@ -3,6 +3,7 @@ package com.codacy.parsers.implementation
 import java.io.File
 
 import com.codacy.api.{CoverageFileReport, CoverageReport}
+import com.codacy.parsers.util.MathUtils._
 import com.codacy.parsers.util.TextUtils
 import com.codacy.parsers.{CoverageParser, XmlReportParser}
 
@@ -53,7 +54,7 @@ object CoberturaParser extends CoverageParser with XmlReportParser {
       (for {
         xClass <- classes
         line <- xClass \\ "line"
-      } yield (line \@ "number").toInt -> (line \@ "hits").toInt).toMap
+      } yield (line \@ "number").toInt -> (line \@ "hits").toIntOrMaxValue).toMap
 
     CoverageFileReport(sourceFilename, fileHit, lineHitMap)
   }

--- a/src/main/scala/com/codacy/parsers/implementation/LCOVParser.scala
+++ b/src/main/scala/com/codacy/parsers/implementation/LCOVParser.scala
@@ -1,6 +1,7 @@
 package com.codacy.parsers.implementation
 
 import com.codacy.parsers.CoverageParser
+import com.codacy.parsers.util.MathUtils._
 import com.codacy.api.{CoverageFileReport, CoverageReport}
 import java.io.File
 
@@ -41,7 +42,7 @@ object LCOVParser extends CoverageParser {
                 case Some(value) =>
                   val coverage = next.stripPrefix(DA).split(",")
                   if (coverage.length >= 2 && coverage.forall(_ forall Character.isDigit)) {
-                    val coverageValue = coverage.map(_.toInt)
+                    val coverageValue = coverage.map(_.toIntOrMaxValue)
                     Right(
                       value.copy(coverage = value.coverage + (coverageValue(0) -> coverageValue(1))) +: reports.tail
                     )

--- a/src/main/scala/com/codacy/parsers/util/MathUtils.scala
+++ b/src/main/scala/com/codacy/parsers/util/MathUtils.scala
@@ -5,4 +5,13 @@ object MathUtils {
   def computePercentage(part: Int, total: Int): Int = {
     if (total == 0) 0 else math.round((part.toFloat / total) * 100)
   }
+
+  implicit class ParseIntOps(val s: String) extends AnyVal {
+
+    def toIntOrMaxValue: Int = {
+      val long = s.toLong
+      if (long > Int.MaxValue) Int.MaxValue
+      else long.toInt
+    }
+  }
 }


### PR DESCRIPTION
This applies to Cobertura and LCOV only. Notice that a more long-term solution
is to use `Long` to represent these possibly big numbers.
The long term solution is stated in: https://codacy.atlassian.net/browse/CY-3314